### PR TITLE
Regex updated for allow hyphen on id.

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -15,7 +15,7 @@ module.exports = function(meta) {
 			throw new Error("Missing required package id.");
 		}
 
-		if (!/^[a-z0-9\.]+$/i.test(meta.id)) {
+		if (!/^[a-z0-9\.]+(-[a-z0-9\.]+)*$/i.test(meta.id)) {
 			throw new Error("Package id isn't in a valid format.");
 		}
 


### PR DESCRIPTION
Only one simultaneous occurrence can follow without having a word in between, no hyphen on the beginning neither on end of the id.